### PR TITLE
[irods/externals#263] Update externals references for clang 16

### DIFF
--- a/.github/workflows/linter-irods-clang-format.yml
+++ b/.github/workflows/linter-irods-clang-format.yml
@@ -26,11 +26,11 @@ jobs:
                   wget -qO - https://unstable.irods.org/irods-unstable-signing-key.asc | sudo apt-key add -
                   echo "deb [arch=amd64] https://unstable.irods.org/apt/ $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/renci-irods-unstable.list
                   sudo apt-get update -qq
-                  sudo apt-get install -qq irods-externals-clang13.0.1-0
+                  sudo apt-get install -qq irods-externals-clang16.0.6-0
             - name: Run Clang-Format
               run: |
                   # Make clang-format available.
-                  export PATH=/opt/irods-externals/clang13.0.1-0/bin:$PATH
+                  export PATH=/opt/irods-externals/clang16.0.6-0/bin:$PATH
 
                   # Configure Git so that "git clang-format" can be run.
                   git config --global clangFormat.binary clang-format

--- a/.github/workflows/linter-irods-clang-tidy.yml
+++ b/.github/workflows/linter-irods-clang-tidy.yml
@@ -54,29 +54,35 @@ jobs:
                 wget -qO - https://unstable.irods.org/irods-unstable-signing-key.asc | sudo apt-key add -
                 echo "deb [arch=amd64] https://unstable.irods.org/apt/ $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/renci-irods-unstable.list
                 sudo apt-get update -qq
+                # iRODS 4.3.4
                 sudo apt-get install -qq \
-                    irods-externals-avro1.11.0-3 \
                     irods-externals-avro-libcxx1.11.0-3 \
-                    irods-externals-boost1.81.0-1 \
                     irods-externals-boost-libcxx1.81.0-1 \
                     irods-externals-catch22.13.8-0 \
                     irods-externals-clang13.0.1-0 \
                     irods-externals-clang-runtime13.0.1-0 \
                     irods-externals-cppzmq4.8.1-1 \
-                    irods-externals-fmt8.1.1-1 \
                     irods-externals-fmt-libcxx8.1.1-1 \
+                    irods-externals-json3.10.4-0 \
+                    irods-externals-jwt-cpp0.6.99.1-0 \
+                    irods-externals-nanodbc-libcxx2.13.0-2 \
+                    irods-externals-qpid-proton-libcxx0.36.0-2 \
+                    irods-externals-redis4.0.10-0 \
+                    irods-externals-spdlog-libcxx1.9.2-2 \
+                    irods-externals-zeromq4-1-libcxx4.1.8-1
+                # iRODS 5.0.0
+                sudo apt-get install -qq \
+                    irods-externals-boost1.81.0-2 \
+                    irods-externals-catch22.13.8-0 \
+                    irods-externals-clang16.0.6-0 \
+                    irods-externals-fmt8.1.1-2 \
                     irods-externals-json3.10.4-0 \
                     irods-externals-jsoncons0.178.0-0 \
                     irods-externals-jwt-cpp0.6.99.1-0 \
-                    irods-externals-nanodbc2.13.0-2 \
-                    irods-externals-nanodbc-libcxx2.13.0-2 \
-                    irods-externals-qpid-proton0.36.0-2 \
-                    irods-externals-qpid-proton-libcxx0.36.0-2 \
-                    irods-externals-redis4.0.10-0 \
-                    irods-externals-spdlog1.9.2-2 \
-                    irods-externals-spdlog-libcxx1.9.2-2 \
-                    irods-externals-zeromq4-14.1.8-1 \
-                    irods-externals-zeromq4-1-libcxx4.1.8-1
+                    irods-externals-nanodbc2.13.0-3 \
+                    irods-externals-qpid-proton0.36.0-3 \
+                    irods-externals-redis4.0.10-1 \
+                    irods-externals-spdlog1.9.2-3
             - name: Install iRODS Development Package
               if: ${{ inputs.install_irods_development_package }}
               run: |
@@ -90,8 +96,8 @@ jobs:
             - name: Run Clang-Tidy
               run: |
                 # Make clang and clang-tidy available.
-                export PATH=/opt/irods-externals/clang13.0.1-0/bin:$PATH
-                export PATH=/opt/irods-externals/clang13.0.1-0/share/clang:$PATH
+                export PATH=/opt/irods-externals/clang16.0.6-0/bin:$PATH
+                export PATH=/opt/irods-externals/clang16.0.6-0/share/clang:$PATH
 
                 # Run clang-tidy on the changes.
                 git diff -U0 origin/$GITHUB_BASE_REF | \


### PR DESCRIPTION
In service of irods/externals#263

Do not merge before new externals packages are in the package repos.